### PR TITLE
Use bright green for RUNNING status in dashboard

### DIFF
--- a/octopoid-dash.py
+++ b/octopoid-dash.py
@@ -464,8 +464,16 @@ def init_colors():
     """Initialize color pairs."""
     curses.start_color()
     curses.use_default_colors()
+
+    # Try to use bright green (color 10) for RUNNING if 256 colors are supported
+    # Color 10 is "bright green" in 256-color terminals, making RUNNING more prominent
+    if curses.COLORS >= 256:
+        bright_green = 10  # Bright green in 256-color palette
+    else:
+        bright_green = curses.COLOR_GREEN
+
     curses.init_pair(Colors.HEADER, curses.COLOR_CYAN, -1)
-    curses.init_pair(Colors.RUNNING, curses.COLOR_GREEN, -1)
+    curses.init_pair(Colors.RUNNING, bright_green, -1)
     curses.init_pair(Colors.SUCCESS, curses.COLOR_GREEN, -1)
     curses.init_pair(Colors.FAILURE, curses.COLOR_RED, -1)
     curses.init_pair(Colors.WARNING, curses.COLOR_YELLOW, -1)


### PR DESCRIPTION
## Summary

- Use bright green (color 10) for RUNNING agents in 256-color terminals
- Falls back to standard green on terminals without 256-color support
- Complements the existing bold attribute to make RUNNING agents more visually prominent

This builds on the sorting and bold changes from commit 8ffbd79 by adding actual color brightness for terminals that support it.

## Test plan

- [ ] Run dashboard in a 256-color terminal (most modern terminals) - RUNNING status should be visibly brighter green
- [ ] Run dashboard in a basic terminal - RUNNING status should still use standard green (graceful fallback)
- [ ] Verify sorting still works: RUNNING agents at top, IDLE in middle, PAUSED at bottom

🤖 Generated with [Claude Code](https://claude.com/claude-code)