### PR TITLE
Simplify handle_agent_result with state-first pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - `submit-pr` script now calls server submit endpoint directly, ensuring tasks transition from `claimed` to `provisional` even if agents don't exit immediately
+- `handle_agent_result()` now uses state-first pattern to handle race conditions gracefully (expired leases, submit-pr races) and avoid incorrect function calls
 
 ### Added
 - Breakdown depth tracking to prevent infinite re-breakdown loops (GH-10)


### PR DESCRIPTION
## Summary

Rewrites `handle_agent_result()` in `orchestrator/scheduler.py` to use a state-first pattern that handles race conditions gracefully.

### Changes

1. **State-first pattern**: Fetch current task state from server first, then switch on `current_queue × outcome`
2. **Fixed wrong function calls**: No more calls to `queue_utils.fail_task()` or `mark_needs_continuation()` with wrong arguments (these functions expect `Path` not `task_id`)
3. **Direct SDK calls**: Uses `sdk.tasks.update()` directly for queue changes instead of calling queue_utils helpers
4. **Graceful race handling**: 
   - Handles submit-pr race (task already provisional)
   - Handles lease-monitor race (task already incoming)
5. **Idempotent**: Safe to call multiple times
6. **Better error handling**: No broad catch-all exception handlers that mask errors

### Helper Functions Extracted

- `_count_commits()`: Count commits in worktree
- `_update_pr_metadata()`: Update PR URL and number
- `_handle_submit_outcome()`: Handle submitted/done based on current state
- `_handle_fail_outcome()`: Handle failed based on current state
- `_handle_continuation_outcome()`: Handle needs_continuation based on state

### Testing

All existing tests pass (543 passed, 14 failures are pre-existing and unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)