### PR TITLE
[e210e05a] Fix worktree creation when project branch is already checked out

### DIFF
--- a/orchestrator/git_utils.py
+++ b/orchestrator/git_utils.py
@@ -239,8 +239,9 @@ def create_task_worktree(task: dict) -> Path:
     if branch_exists_locally:
         # Branch exists locally (possibly checked out elsewhere)
         # Use existing branch as start point without -b flag
+        # Use --force to allow checking out the same branch in multiple worktrees
         run_git(
-            ["worktree", "add", str(worktree_path), branch],
+            ["worktree", "add", "--force", str(worktree_path), branch],
             cwd=parent_repo,
         )
     elif branch_exists_on_origin:


### PR DESCRIPTION
## Summary

Automated implementation for task [e210e05a].

## Changes

```
e96e12a fix: add --force flag to allow same branch in multiple worktrees
bf4014e fix: handle worktree creation when project branch is checked out
```

---
Generated by orchestrator agent: implementer-2