### PR TITLE
[TASK-122a2495] Switch implementer agents to sonnet-4.5 model

### DIFF
--- a/.octopoid/agents.yaml
+++ b/.octopoid/agents.yaml
@@ -11,14 +11,14 @@ fleet:
     enabled: true
     interval_seconds: 60
     max_turns: 200
-    model: sonnet
+    model: claude-sonnet-4-5-20250929
 
   - name: implementer-2
     type: implementer
     enabled: true
     interval_seconds: 60
     max_turns: 200
-    model: sonnet
+    model: claude-sonnet-4-5-20250929
 
   - name: sanity-check-gatekeeper
     role: gatekeeper

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Implementer agents now use `claude-sonnet-4-5-20250929`** — updated `.octopoid/agents.yaml` to pin the explicit model ID instead of the `sonnet` alias, which currently resolves to `claude-sonnet-4-6`
+
 ### Added
 
 - **Flow-driven scheduler execution** ([TASK-f584b935])


### PR DESCRIPTION
## Summary

Automated implementation for task [TASK-122a2495].

## Changes

```
a544269 chore: pin implementer agents to claude-sonnet-4-5-20250929
```

---
Generated by orchestrator agent: implementer-1