### PR TITLE
[TASK-b0a63d8b] Fix gatekeeper: remove old Python role, fix claim role_filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Gatekeeper claim bug** ([TASK-b0a63d8b])
+  - `guard_claim_task` now passes `role_filter=None` when claiming from non-incoming queues (e.g. `provisional`), so the gatekeeper can claim tasks whose original `role` is `"implement"` rather than `"gatekeeper"`
+  - Added `role_filter` parameter to `claim_and_prepare_task` with a sentinel default so callers can explicitly pass `None` to disable role filtering
+
 ### Added
 
 - **Implementer as pure-function via flow steps** ([TASK-2bf1ad9b])


### PR DESCRIPTION
## Summary

Automated implementation for task [TASK-b0a63d8b].

## Changes

```
d1474bd fix: gatekeeper role_filter — pass None when claiming from non-incoming queues
```

---
Generated by orchestrator agent: implementer-1