### PR TITLE
[e8d479f9] Fix CI: update pnpm-lock.yaml for submodules/server

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,7 +64,13 @@ importers:
         specifier: ^5.3.3
         version: 5.9.3
 
-  packages/server:
+  packages/shared:
+    devDependencies:
+      typescript:
+        specifier: ^5.3.3
+        version: 5.9.3
+
+  submodules/server:
     dependencies:
       hono:
         specifier: ^4.0.0
@@ -82,12 +88,6 @@ importers:
       wrangler:
         specifier: ^3.28.0
         version: 3.114.17(@cloudflare/workers-types@4.20260210.0)
-
-  packages/shared:
-    devDependencies:
-      typescript:
-        specifier: ^5.3.3
-        version: 5.9.3
 
 packages:
 


### PR DESCRIPTION
## Summary

Updates pnpm-lock.yaml to include submodules/server dependencies (hono, @cloudflare/workers-types, typescript, vitest, wrangler) so CI passes the `--frozen-lockfile` install step.

## Changes

```
c06bb69 fix: update pnpm-lock.yaml to include submodules/server dependencies
```