### PR TITLE
[4275b19f] Fix JSON output inference: wrong subtype string + empty result fallback

### DIFF
--- a/octopoid/result_handler.py
+++ b/octopoid/result_handler.py
@@ -251,14 +251,20 @@ def infer_result_from_stdout(stdout_path: Path, agent_role: str) -> dict:
     if parsed_json is not None:
         subtype = parsed_json.get("subtype", "")
         logger.debug(f"infer_result_from_stdout: JSON stdout detected, subtype={subtype!r}")
-        if subtype == "error_max_turns_exceeded":
+        if subtype == "error_max_turns":
             if agent_role in ("gatekeeper", "sanity-check-gatekeeper"):
                 return {"status": "failure", "message": "Agent hit max turns limit"}
             return {"outcome": "max_turns_exceeded", "reason": "Agent hit max turns limit"}
         # For other subtypes (success, other errors) use the extracted text
-        # as the inference payload.  If text is empty, fall through to the
-        # empty-stdout path handled below.
+        # as the inference payload.  If text is empty, classify from subtype
+        # and is_error rather than returning unknown blindly.
         if not text.strip():
+            is_error = parsed_json.get("is_error", False)
+            if is_error:
+                if agent_role in ("gatekeeper", "sanity-check-gatekeeper"):
+                    return {"status": "failure", "message": f"Agent error with empty result (subtype={subtype!r})"}
+                return {"outcome": "failed", "reason": f"Agent error with empty result (subtype={subtype!r})"}
+            # Non-error with empty result — cannot verify success without text
             if agent_role in ("gatekeeper", "sanity-check-gatekeeper"):
                 return {"status": "failure", "message": "Empty result in JSON stdout"}
             return {"outcome": "unknown", "reason": "Empty result in JSON stdout"}

--- a/octopoid/scheduler.py
+++ b/octopoid/scheduler.py
@@ -1276,6 +1276,7 @@ def invoke_claude(task_dir: Path, agent_config: dict) -> int:
         "--allowedTools", "Read,Write,Edit,Glob,Grep,Bash,Skill",
         "--max-turns", str(max_turns),
         "--model", model,
+        "--output-format", "json",
     ]
 
     # Write PostToolUse hook into worktree so the agent tracks turn counts.

--- a/tests/test_result_inference.py
+++ b/tests/test_result_inference.py
@@ -376,11 +376,24 @@ class TestJsonStdoutParsing:
         assert captured[0] == result_text
 
     def test_json_max_turns_exceeded_returns_max_turns_outcome(self, tmp_path):
-        """JSON stdout with subtype='error_max_turns_exceeded' returns max_turns_exceeded outcome."""
+        """JSON stdout with subtype='error_max_turns' returns max_turns_exceeded outcome."""
         from octopoid.result_handler import infer_result_from_stdout
 
         (tmp_path / "stdout.log").write_text(
-            self._json_stdout("error_max_turns_exceeded", "Partial work done.")
+            self._json_stdout("error_max_turns", "Partial work done.")
+        )
+
+        result = infer_result_from_stdout(tmp_path / "stdout.log", "implement")
+
+        assert result["outcome"] == "max_turns_exceeded"
+        assert result["outcome"] != "unknown"
+
+    def test_json_max_turns_with_empty_result_returns_max_turns_outcome(self, tmp_path):
+        """JSON stdout with subtype='error_max_turns' and empty result still returns max_turns_exceeded."""
+        from octopoid.result_handler import infer_result_from_stdout
+
+        (tmp_path / "stdout.log").write_text(
+            self._json_stdout("error_max_turns", "")
         )
 
         result = infer_result_from_stdout(tmp_path / "stdout.log", "implement")
@@ -389,17 +402,69 @@ class TestJsonStdoutParsing:
         assert result["outcome"] != "unknown"
 
     def test_json_max_turns_gatekeeper_returns_failure(self, tmp_path):
-        """JSON max_turns_exceeded for gatekeeper role returns status=failure."""
+        """JSON error_max_turns for gatekeeper role returns status=failure."""
         from octopoid.result_handler import infer_result_from_stdout
 
         (tmp_path / "stdout.log").write_text(
-            self._json_stdout("error_max_turns_exceeded")
+            self._json_stdout("error_max_turns")
         )
 
         result = infer_result_from_stdout(tmp_path / "stdout.log", "gatekeeper")
 
         assert result["status"] == "failure"
         assert "max turns" in result.get("message", "").lower()
+
+    def test_json_is_error_with_empty_result_returns_failed(self, tmp_path):
+        """JSON stdout with is_error=True and empty result returns outcome=failed (not unknown)."""
+        import json
+        from octopoid.result_handler import infer_result_from_stdout
+
+        payload = json.dumps({
+            "type": "result",
+            "subtype": "error_api_error",
+            "is_error": True,
+            "result": "",
+        })
+        (tmp_path / "stdout.log").write_text(payload)
+
+        result = infer_result_from_stdout(tmp_path / "stdout.log", "implement")
+
+        assert result["outcome"] == "failed"
+        assert result["outcome"] != "unknown"
+
+    def test_json_is_error_with_empty_result_gatekeeper_returns_failure(self, tmp_path):
+        """JSON stdout with is_error=True and empty result for gatekeeper returns status=failure."""
+        import json
+        from octopoid.result_handler import infer_result_from_stdout
+
+        payload = json.dumps({
+            "type": "result",
+            "subtype": "error_api_error",
+            "is_error": True,
+            "result": "",
+        })
+        (tmp_path / "stdout.log").write_text(payload)
+
+        result = infer_result_from_stdout(tmp_path / "stdout.log", "gatekeeper")
+
+        assert result["status"] == "failure"
+
+    def test_json_non_error_empty_result_returns_unknown(self, tmp_path):
+        """JSON stdout with is_error=False and empty result returns outcome=unknown."""
+        import json
+        from octopoid.result_handler import infer_result_from_stdout
+
+        payload = json.dumps({
+            "type": "result",
+            "subtype": "success",
+            "is_error": False,
+            "result": "",
+        })
+        (tmp_path / "stdout.log").write_text(payload)
+
+        result = infer_result_from_stdout(tmp_path / "stdout.log", "implement")
+
+        assert result["outcome"] == "unknown"
 
     def test_plain_text_stdout_still_works(self, tmp_path):
         """Plain-text stdout (pre-json agents) still classifies correctly (backwards compat)."""


### PR DESCRIPTION
## Summary

Automated implementation for task [4275b19f].

## Changes

```

```
