### PR TITLE
[5d573f42] Remove unused variable 'staging_url' in reports.py (vulture)

### DIFF
--- a/octopoid/reports.py
+++ b/octopoid/reports.py
@@ -317,7 +317,7 @@ def _extract_staging_url(pr_number: int) -> str | None:
         return None
 
 
-def _store_staging_url(pr_number: int, _staging_url: str, *, branch_name: str | None = None, sdk: Optional["OctopoidSDK"] = None) -> None:
+def _store_staging_url(pr_number: int, *, branch_name: str | None = None, sdk: Optional["OctopoidSDK"] = None) -> None:
     """Store a staging URL on the task associated with a PR number.
 
     Looks up the task by pr_number first. If that fails and a branch_name
@@ -326,7 +326,6 @@ def _store_staging_url(pr_number: int, _staging_url: str, *, branch_name: str | 
 
     Args:
         pr_number: PR number to look up
-        _staging_url: URL to store (currently unused — SDK update not yet implemented)
         branch_name: Optional branch name for fallback lookup
         sdk: Optional SDK for v2.0 API mode
     """

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -855,7 +855,7 @@ class TestStoreStagingUrl:
 
     def test_noop_without_db(self):
         # Should not raise - DB mode is always off now
-        _store_staging_url(55, "https://preview.pages.dev")
+        _store_staging_url(55)
 
 
 class TestFormatTaskStagingUrl:


### PR DESCRIPTION
## Summary

Automated implementation for task [5d573f42].

## Changes

```

```
